### PR TITLE
Added bower.json file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,24 @@
+{
+  "name": "open-fb",
+  "main": "OpenFB.js",
+  "version": "0.0.1",
+  "homepage": "https://github.com/sunshineo/openfb",
+  "authors": [
+    "sunshineo",
+    "ccoenraets"
+  ],
+  "description": "Micro-library that lets you integrate browser and Cordova apps with Facebook with no plugin or SDK dependency",
+  "keywords": [
+    "cordova",
+    "facebook",
+    "openfb"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
I feel this code would be beneficial if it were available through bower (even though it has zero dependencies) so I took the liberty of creating a bower file. It does unfortunately require renaming to match the bower naming requirements "Lowercase, a-z, can contain digits".

I though "open-fb" would work but feel free to change.

- merge
- change name
- run `bower register open-fb https://github.com/sunshineo/open-fb`